### PR TITLE
Added an invisible rect shape for easy grouping

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,6 +207,21 @@
 				background-color: lightgrey;
 			}
 
+			.newMockElement.invisiblerect, .mockElement.invisiblerect {
+				width:200px;
+				height:50px;
+				margin:2px;
+			}
+
+			.mockElement.invisiblerect > .desc {
+				display:none;
+			}
+
+			.newMockElement.invisiblerect, .mockElement.invisiblerect:hover, .mockElement.invisiblerect.custom-selected {
+				border:2px solid lightgrey;
+				margin:0;
+			}
+
 			.newMockElement.whiterect , .mockElement.whiterect{
 				border:2px solid rgba(150,150,150,0.05);
 				width:200px;
@@ -832,6 +847,11 @@ Paragraph
 				</li>
 				<li title="a gray rectangle">
 					<div class="newMockElement grayrect">
+					</div>
+				</li>
+				<li title="an invisible rectangle">
+					<div class="newMockElement invisiblerect">
+						<div class="desc">Invisible Rect<br>Use for grouping</div>
 					</div>
 				</li>
 				<li title="horizontal list">

--- a/index.html
+++ b/index.html
@@ -210,6 +210,7 @@
 			.newMockElement.invisiblerect, .mockElement.invisiblerect {
 				width:200px;
 				height:50px;
+				background-color: transparent;
 				margin:2px;
 			}
 


### PR DESCRIPTION
I love the fact quickMockup has no group / ungroup feature, or selection rectangles. It makes everything really easy and simple! But the ability to put stuff in an empty box, if only to duplicate and re-position would be really useful.

Hence this pull request.

Fixes #33 
